### PR TITLE
Fix docstrings referencing wrong filenames

### DIFF
--- a/diarizacao.py
+++ b/diarizacao.py
@@ -1,5 +1,5 @@
 """
-diarize_audio.py
+diarizacao.py
 Script para diarização de áudio com compatibilidade melhorada.
 Identifica oradores e agrupa falas consecutivas.
 """

--- a/transcricao.py
+++ b/transcricao.py
@@ -1,5 +1,5 @@
 """
-diarize_audio.py
+transcricao.py
 Script completo para diarização com compatibilidade garantida
 """
 


### PR DESCRIPTION
## Summary
- update the module name in the diarizacao.py docstring
- update the module name in the transcricao.py docstring

## Testing
- `python3 -m py_compile diarizacao.py transcricao.py`


------
https://chatgpt.com/codex/tasks/task_e_684ace75a008832f80720dfd0735debb